### PR TITLE
Disable request cache from default security filter chain.

### DIFF
--- a/samples/mfa-authorizationserver/src/main/java/sample/config/SecurityConfiguration.java
+++ b/samples/mfa-authorizationserver/src/main/java/sample/config/SecurityConfiguration.java
@@ -84,6 +84,7 @@ public class SecurityConfiguration {
                     .antMatchers("/security-question").hasAuthority("SECURITY_QUESTION_REQUIRED")
                     .anyRequest().hasRole("USER")
             )
+			.requestCache(cache -> cache.disable())
             .formLogin((formLogin) ->
                 formLogin
                     .loginPage("/login")


### PR DESCRIPTION
I previously asked a question on Stack Overflow regarding [preventing the override of RequestCache](https://stackoverflow.com/questions/75486641/how-can-i-prevent-requestcache-from-being-overriden). As I mentioned, I encountered an issue where accessing **/security-question** without authentication would override the request cache from the **/oauth/authorize** endpoint. This could result in the loss of important data, such as the **code_challenge** in the case of an OAuth2 PKCE flow

_Best regards,_